### PR TITLE
Support building bins for multiple `:platforms` in one invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ clojure -X:jar && clojure -X:bin
 - `:name` sym-or-str        -- specify the name of the generated BIN file
 - `:skip-realign` true      -- if should skip byte alignment repair.
 - `:jvm-opts` [strs]        -- optional list of JVM options to use during bin executing
+- `:platforms` [kws]        -- optional list of platforms for which to emit bins, valid kws: :unix, :windows, defaults to system platform
 
 ## Contribution
 

--- a/src/deps_bin/impl/bin.clj
+++ b/src/deps_bin/impl/bin.clj
@@ -49,7 +49,7 @@
   (fs/chmod "+x" bin-file))
 
 (defn ^:private coerce-platforms [coll]
-  (if-some [platforms (not-empty (->> coll (keep allowed-platforms) (distinct)))]
+  (if-some [platforms (->> coll (keep allowed-platforms) distinct not-empty)]
     platforms
     [(system-platform)]))
 
@@ -71,6 +71,7 @@
   Returns a hash map containing:
   * `:success` -- `true` or `false`
   * `:bin-path` -- On `:success`, it is the abs path to the binary.
+  * `:bin-paths` -- Same as above, but when building for multiple platforms.
   * `:reason` -- if `:success` is `false`, this explains what failed:
     * `:help` -- help was requested
     * `:no-jar` -- the `:jar` option was missing

--- a/src/deps_bin/impl/bin.clj
+++ b/src/deps_bin/impl/bin.clj
@@ -6,13 +6,23 @@
    [clostache.parser :refer [render]]
    [me.raynes.fs :as fs]))
 
-(def ^:private windows?
-  (str/starts-with? (System/getProperty "os.name") "Windows"))
+(def ^:private allowed-platforms
+  #{:unix :windows})
 
-(def ^:private preamble-template
-  (if windows?
-    "@echo off\r\njava {{{jvm-opts}}} -jar \"%~f0\" %*\r\nexit /b %errorlevel%\r\n"
-    "#!/usr/bin/env bash\nexec java {{{jvm-opts}}} -jar $0 \"$@\"\ngoto :eof\n"))
+(defn ^:private system-platform []
+  (if (str/starts-with? (System/getProperty "os.name") "Windows")
+    :windows
+    :unix))
+
+(defn ^:private platform-filename [platform name]
+  (case platform
+    :windows (str name ".bat")
+    :unix name))
+
+(defn ^:private preamble-template [platform]
+  (case platform
+    :unix    "#!/usr/bin/env bash\nexec java {{{jvm-opts}}} -jar $0 \"$@\"\ngoto :eof\n"
+    :windows "@echo off\r\njava {{{jvm-opts}}} -jar \"%~f0\" %*\r\nexit /b %errorlevel%\r\n"))
 
 (defn ^:private print-help []
   (println "library usage:")
@@ -22,11 +32,13 @@
   (println "  :jar sym-or-str    -- specify the source name of the JAR file")
   (println "  :name sym-or-str   -- specify the name of the generated BIN file")
   (println "  :skip-realign true -- whether should skip byte alignment repair")
-  (println "  :jvm-opts [strs]   -- optional list of JVM options to use during bin executing"))
+  (println "  :jvm-opts [strs]   -- optional list of JVM options to use during bin executing")
+  (println "  :platforms [kws]   -- optional list of platforms for which to emit bins,")
+  (println "                        valid kws: :unix, :windows, defaults to system platform"))
 
-(defn ^:private preamble [{:keys [jvm-opts] :as  options}]
-  (-> (render preamble-template (merge options
-                                       {:jvm-opts (str/join " " jvm-opts)}))
+(defn ^:private preamble [platform {:keys [jvm-opts] :as  options}]
+  (-> (preamble-template platform)
+      (render (merge options {:jvm-opts (str/join " " jvm-opts)}))
       (str/replace #"\\\$" "\\$")))
 
 (defn ^:private write-bin [bin-file jar preamble]
@@ -35,6 +47,24 @@
     (.write bin (.getBytes preamble))
     (io/copy (fs/file jar) bin))
   (fs/chmod "+x" bin-file))
+
+(defn ^:private coerce-platforms [coll]
+  (if-some [platforms (not-empty (->> coll (keep allowed-platforms) (distinct)))]
+    platforms
+    [(system-platform)]))
+
+(defn emit-bin!
+  "Writes bin, optionally re-aligns it and returns its canonical path."
+  [platform {:keys [jar name skip-realign] :as options}]
+  (let [name     (platform-filename platform name)
+        bin-file (io/file name)
+        preamble (preamble platform options)]
+    (println "Creating" (clojure.core/name platform) "standalone executable:" name)
+    (write-bin name jar preamble)
+    (when-not skip-realign
+      (println "Re-aligning zip offsets...")
+      (repair-zip-with-preamble-bytes bin-file))
+    (.getCanonicalPath bin-file)))
 
 (defn build-bin
   "Core functionality for deps-bin. Can be called from a REPL or as a library.
@@ -46,7 +76,7 @@
     * `:no-jar` -- the `:jar` option was missing
     * `:no-name` -- the `:name` option was missing
   Additional detail about success and failure is also logged."
-  [{:keys [help jar name skip-realign] :as options}]
+  [{:keys [help jar name skip-realign platforms] :as options}]
   (cond
 
     help
@@ -59,15 +89,11 @@
     {:success false :reason :no-name}
 
     :else
-    (let [name (if windows? (str name ".bat") name)
-          bin-file (io/file name)]
-      (println "Creating standalone executable:" name)
-      (write-bin name jar (preamble options))
-      (when-not skip-realign
-        (println "Re-aligning zip offsets...")
-        (repair-zip-with-preamble-bytes bin-file))
-      {:success true
-       :bin-path (.getCanonicalPath bin-file)})))
+    (let [platforms     (coerce-platforms platforms)
+          emitted-paths (mapv #(emit-bin! % options) platforms)]
+      (if (= (count emitted-paths) 1)
+        {:success true :bin-path (first emitted-paths)}
+        {:success true :bin-paths emitted-paths}))))
 
 (defn build-bin-as-main
   "Command-line entry point for `-X` (and legacy `-M`) that performs

--- a/test/deps_bin/impl/bin_test.clj
+++ b/test/deps_bin/impl/bin_test.clj
@@ -26,7 +26,24 @@
       (is (= {:success true
               :bin-path (str (fs/canonicalize (cond-> "some-bin" (fs/windows?) (str ".bat"))))}
              (bin/build-bin {:jar "some-jar.jar"
-                             :name "some-bin"}))))))
+                             :name "some-bin"})))))
+  (testing "with :platforms provided"
+    (with-redefs [bin/write-bin (constantly nil)
+                  clj-zip-meta/repair-zip-with-preamble-bytes (constantly nil)]
+      (is (= {:success true
+              :bin-paths [(str (fs/canonicalize "some-bin.bat"))
+                          (str (fs/canonicalize "some-bin"))]}
+             (bin/build-bin {:jar "some-jar.jar"
+                             :name "some-bin"
+                             :platforms ["foo" :windows :unix :unix]})))))
+  (testing "with invalid :platforms, default to system platform"
+    (with-redefs [bin/write-bin (constantly nil)
+                  clj-zip-meta/repair-zip-with-preamble-bytes (constantly nil)]
+      (is (= {:success true
+              :bin-path (str (fs/canonicalize (cond-> "some-bin" (fs/windows?) (str ".bat"))))}
+             (bin/build-bin {:jar "some-jar.jar"
+                             :name "some-bin"
+                             :platforms [:bad-platform]}))))))
 
 (deftest binary
   (let [test-jar "test/test-jar/testjar.jar"]


### PR DESCRIPTION
Adds the optional `:platforms` option. Providing e.g. `:platforms [:unix :windows]` will build bins for both platforms. When not provided, falls back to the system platform, which was the only option before this PR. See added tests as well.

